### PR TITLE
Introduce Tox Job for Multi-Version Ansible Testing in CI

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -51,3 +51,24 @@ jobs:
         with:
           image: ${{ matrix.config.image }}
           tag: ${{ matrix.config.tag }}
+
+  tox:
+    needs:
+      - lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox -r requirements.txt
+
+      - name: Run tox
+        run: tox


### PR DESCRIPTION
This pull request introduces a new job, named `tox`, to the GitHub Actions workflow (`molecule.yml`). This job leverages `tox` to execute the Molecule test suite across multiple versions of Ansible, as defined in the `tox.ini` configuration file.

The existing `test` job, which utilises `robertdebock/molecule-action` to run Molecule tests against different Linux distributions (Debian and Ubuntu), remains unchanged and will continue to run in parallel.

**Motivation and Context:**

The primary motivation for this change is to enhance the testing coverage of the Ansible role. While the existing `test` job ensures compatibility across different target distributions, the new `tox` job specifically validates the role's functionality against various supported versions of Ansible core. This dual approach provides a more comprehensive testing strategy, increasing confidence in the role's robustness and compatibility.

**How Has This Been Tested?**

The functionality introduced by this change is tested implicitly through the GitHub Actions workflow itself. The successful execution of the new `tox` job within the CI pipeline, alongside the existing `lint` and `test` jobs, serves as validation that `tox` is correctly installed, configured, and executing the Molecule tests as intended across the specified Ansible versions. No manual testing procedures were required beyond observing the CI results.

**Screenshots (if appropriate):**

N/A

**Types of Changes:**

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist:**

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
